### PR TITLE
update allocated message buffer size to avoid hardcoded number.

### DIFF
--- a/zmq.tcl
+++ b/zmq.tcl
@@ -2190,7 +2190,7 @@ critcl::ccommand ::zmq::message {cd ip objc objv} {
 	}
 	}
     }
-    msgp = ckalloc(32);
+    msgp = ckalloc(sizeof(zmq_msg_t));
     if (data) {
 	void* buffer = 0;
 	if (size < 0)


### PR DESCRIPTION
The size of zmq_msg_t was increased from 32 bytes to 64 bytes in v4.2.0-rc1 about 2.5 years ago:
https://github.com/zeromq/libzmq/commit/90194036bf824d78e13955ab931a70e929d356c1

Failure to allocate a large enough buffer causes memory corruption and typically ckfree() faults when trying to close the message.